### PR TITLE
Fix HTML career section and improve site display

### DIFF
--- a/output/html/zukizukizuki_2025-06-08.html
+++ b/output/html/zukizukizuki_2025-06-08.html
@@ -240,6 +240,150 @@
                 </thead>
                 <tbody>
                     
+                    <tr>
+                        <td class="center">1</td>
+                        <td class="center">2012年4月〜2018年7月</td>
+                        <td class="career-description">■DC常駐業務<br>・申請書作成およびマクロ作成<br>・サーバ停止起動<br>・サーバ外観チェック<br>・バックアップ媒体管理<br>・障害連絡<br>・DC入館アテンド</td>
+                        <td>VBA,  VBS,  Batch</td>
+                        <td></td>
+                        <td></td>
+                        <td>ヘルプデスク  <br>規模: 11～50名  </td>
+                        <td class="phase-check"></td>
+                        <td class="phase-check"></td>
+                        <td class="phase-check"></td>
+                        <td class="phase-check"></td>
+                        <td class="phase-check"></td>
+                        <td class="phase-check">●</td>
+                    </tr>
+                    
+                    <tr>
+                        <td class="center">2</td>
+                        <td class="center">2018年8月〜2021年1月</td>
+                        <td class="career-description">■インフラ監視、運用保守業務<br>・障害アラート対応<br>・DC駆けつけ対応<br>・サーバ設定変更作業<br>・月次報告書作成およびマクロ作成<br>・シェルスクリプトの作成</td>
+                        <td>Bash shell,  VBA,  VBS,  Batch</td>
+                        <td>Windows,  CentOS</td>
+                        <td>Nagios,  Zabbix,  Cacti,  AWS,  Azure</td>
+                        <td>インフラエンジニア  <br>規模: 11～50名  </td>
+                        <td class="phase-check"></td>
+                        <td class="phase-check"></td>
+                        <td class="phase-check">●</td>
+                        <td class="phase-check">●</td>
+                        <td class="phase-check">●</td>
+                        <td class="phase-check">●</td>
+                    </tr>
+                    
+                    <tr>
+                        <td class="center">3</td>
+                        <td class="center">2021年2月〜2021年7月</td>
+                        <td class="career-description">■大規模運用体制を前提とした運用統括業務<br>・運用管理業務<br>・運用ルール制定、周知業務<br>・定例会議出席<br>・運用業務の改善提案</td>
+                        <td>VBA,  VBS</td>
+                        <td>Windows,  CentOS</td>
+                        <td>Hinemos,  Bluecoat,  Redmine,  SVN</td>
+                        <td>インフラエンジニア  <br>規模: 11～50名  </td>
+                        <td class="phase-check"></td>
+                        <td class="phase-check">●</td>
+                        <td class="phase-check">●</td>
+                        <td class="phase-check">●</td>
+                        <td class="phase-check"></td>
+                        <td class="phase-check"></td>
+                    </tr>
+                    
+                    <tr>
+                        <td class="center">4</td>
+                        <td class="center">2021年7月〜2022年1月</td>
+                        <td class="career-description">■インフラ運用保守・移行サポート業務<br>・本番稼働システム運用保守業務(apache, postfix, sendmail, bind, samba, nagios, vsftpd, oracleDB)<br>・チームメンバー統括業務<br>・zabbixサーバ構築・検証<br>・apacheサーバ構築・検証<br>・WAF(mod_security)構築・検証<br>・お客様定例会出席</td>
+                        <td>VBA,  VBS,  PowerShell,  Python,  Batch</td>
+                        <td>Windows,  CentOS,  Oracle SQL,  Zabbix,  IIS,  Apache</td>
+                        <td>Git,  Edge DNS,  ISWM,  CMS,  CLUSTERPRO,  ModSecurity</td>
+                        <td>インフラエンジニア  <br>規模: 11～50名  </td>
+                        <td class="phase-check"></td>
+                        <td class="phase-check">●</td>
+                        <td class="phase-check">●</td>
+                        <td class="phase-check">●</td>
+                        <td class="phase-check"></td>
+                        <td class="phase-check"></td>
+                    </tr>
+                    
+                    <tr>
+                        <td class="center">5</td>
+                        <td class="center">2022年2月〜2022年10月</td>
+                        <td class="career-description">■英会話教室向けシステム構築及びシステム運用<br>・Linux、windowsサーバ運用・保守<br>・オンプレ→AWSへのサーバ移行作業<br>・server upgrade対応(脆弱性対応含む)<br>・SQL server移行作業<br>・提供システム障害対応<br>・Cisco switch router設定変更作業<br>・Paloalto GlobalProtectメンテナンス</td>
+                        <td>PowerShell,  Python,  Batch,  Bash</td>
+                        <td>Windows,  RHEL,  Postgres,  Redis,  SQL Server,  Active Directory,  NoSQL</td>
+                        <td>Git,  BIND,  RH Satellite,  Netbox,  AWS,  Salt,  Nagios</td>
+                        <td>インフラエンジニア  <br>規模: 6～10名  </td>
+                        <td class="phase-check">●</td>
+                        <td class="phase-check">●</td>
+                        <td class="phase-check">●</td>
+                        <td class="phase-check">●</td>
+                        <td class="phase-check">●</td>
+                        <td class="phase-check"></td>
+                    </tr>
+                    
+                    <tr>
+                        <td class="center">6</td>
+                        <td class="center">2022年11月〜2023年9月</td>
+                        <td class="career-description">■GCPに構築したデータ分析環境の機能改善と運用<br>・クラウド環境におけるビッグデータ処理基盤の改善活動<br>・Terraformで組織内の権限付与業務、インスタンスの作成<br>・Ansibleでサーバーの設定<br>・GCPのプロダクトやOSのEOSL対応<br>・業務時間内の障害検知・障害対応</td>
+                        <td>Python,  Bash,  terraform,  ansible</td>
+                        <td>Windows,  RHEL,  NoSQL,  BigQuery</td>
+                        <td>GitHub Enterprise,  GCP,  AWS,  docker,  JIRA,  Confluence,  Datadog</td>
+                        <td>インフラエンジニア  <br>規模: 3名  </td>
+                        <td class="phase-check">●</td>
+                        <td class="phase-check">●</td>
+                        <td class="phase-check">●</td>
+                        <td class="phase-check">●</td>
+                        <td class="phase-check">●</td>
+                        <td class="phase-check"></td>
+                    </tr>
+                    
+                    <tr>
+                        <td class="center">7</td>
+                        <td class="center">2023年10月〜2024年5月</td>
+                        <td class="career-description">■病院向けアプリのインフラ開発案件<br>・監視及びサーバ及びネットワークのパラメータシート作成<br>・ネットワーク設計・構築・保守<br>・zabbixサーバ構築・保守<br>・独自監視用scriptの作成<br>・squidサーバ構築・保守<br>・AWS SSMを用いたリモート接続環境の構築・保守<br>・terraformを用いた既存AWSリソースのソース管理の実装<br>・業務時間内の障害検知・障害対応<br>・医療向けアプリリリース作業</td>
+                        <td>Python,  Bash,  powershell,  ansible,  terraform</td>
+                        <td>Windows,  RHEL,  ubuntu,  postgres</td>
+                        <td>GitHub,  GCP,  AWS,  docker,  zabbix,  squid</td>
+                        <td>インフラエンジニア  <br>規模: 5名  </td>
+                        <td class="phase-check">●</td>
+                        <td class="phase-check">●</td>
+                        <td class="phase-check">●</td>
+                        <td class="phase-check">●</td>
+                        <td class="phase-check">●</td>
+                        <td class="phase-check"></td>
+                    </tr>
+                    
+                    <tr>
+                        <td class="center">8</td>
+                        <td class="center">2024年6月〜2025年3月</td>
+                        <td class="career-description">■スマートビルディング事業向けwebアプリのクラウド環境開発・既存システムの保守<br>・github actionsでのCI/CD構築<br>・datadogを用いた監視設計・実装<br>・terraformを用いた既存AWSリソースの実装<br>・terraformを用いた既存GCPリソースの実装<br>・障害対応<br>・脆弱性診断<br>・コスト最適化<br>・新機能開発</td>
+                        <td>Python,  Bash,  powershell,  terraform,  javascript</td>
+                        <td>Windows,  RHEL,  ubuntu,  mysql,  dynamoDB</td>
+                        <td>GitHub,  GCP,  AWS,  docker,  datadog,  Notion,  Bytebase</td>
+                        <td>インフラエンジニア  <br>規模: 4名  </td>
+                        <td class="phase-check">●</td>
+                        <td class="phase-check">●</td>
+                        <td class="phase-check">●</td>
+                        <td class="phase-check">●</td>
+                        <td class="phase-check">●</td>
+                        <td class="phase-check">●</td>
+                    </tr>
+                    
+                    <tr>
+                        <td class="center">9</td>
+                        <td class="center">2025年4月〜現在</td>
+                        <td class="career-description">■人材事業向けwebアプリのクラウド環境の改善<br>・github actionsでのCI/CD構築<br>・Cloud Formationで管理しているリソースのterraform化<br>・障害対応</td>
+                        <td>terraform,  CloudFormation</td>
+                        <td>Windows,  RHEL</td>
+                        <td>GitHub,  AWS,  datadog,  docker</td>
+                        <td>インフラエンジニア  <br>規模: 4名  </td>
+                        <td class="phase-check">●</td>
+                        <td class="phase-check">●</td>
+                        <td class="phase-check">●</td>
+                        <td class="phase-check">●</td>
+                        <td class="phase-check">●</td>
+                        <td class="phase-check"></td>
+                    </tr>
+                    
                 </tbody>
             </table>
         </div>

--- a/output/index.html
+++ b/output/index.html
@@ -29,7 +29,8 @@
         
         <div class="info">
             <strong>💡 自動生成されたスキルシートファイル</strong><br>
-            <a href="https://github.com/zukizukizuki/skill/blob/main/skill-sheets/zukizukizuki.md" target="_blank">Markdownファイル</a>から自動的に変換されたスキルシートをダウンロードできます。
+            <a href="https://github.com/zukizukizuki/skill/blob/main/skill-sheets/zukizukizuki.md" target="_blank">Markdownファイル</a>から自動的に変換されたスキルシートをダウンロードできます。<br>
+            <small>※ 個人情報は含まれていません。詳細な情報は個別にご提供いたします。</small>
         </div>
         
         
@@ -64,7 +65,6 @@
                 <p>Webブラウザで表示可能</p>
                 <div id="html-links">
                     <a href="html/zukizukizuki_2025-06-08.html" class="file-link" target="_blank">zukizukizuki_2025-06-08.html</a>
-<a href="html/zukizukizuki_2025-06-07.html" class="file-link" target="_blank">zukizukizuki_2025-06-07.html</a>
                 </div>
             </div>
         </div>
@@ -77,7 +77,7 @@
         </div>
         
         <div class="timestamp">
-            最終更新: 2025/6/8 10:33:27
+            最終更新: 2025/6/8 10:53:51
         </div>
     </div>
 </body>

--- a/scripts/create-html-skillsheet.js
+++ b/scripts/create-html-skillsheet.js
@@ -401,7 +401,7 @@ function extractCareers(content) {
   const sections = content.split('---');
   
   sections.forEach(section => {
-    if (section.includes('### ') && section.includes('**期間**:')) {
+    if (section.includes('### ') && (section.includes('**役割**:') || section.includes('**期間**:'))) {
       const lines = section.split('\n');
       let period = '';
       let description = '';
@@ -412,7 +412,7 @@ function extractCareers(content) {
       let phases = [false, false, false, false, false, false];
       
       // 期間とプロジェクト名を抽出
-      const titleMatch = section.match(/### (\d+)\. (.*?)（(.*?)）/);
+      const titleMatch = section.match(/### (\d+)\. (.*)（(.*)）/);
       if (titleMatch) {
         period = formatPeriod(titleMatch[3]);
         description = titleMatch[2];
@@ -420,45 +420,45 @@ function extractCareers(content) {
       
       // 使用技術を抽出
       if (section.includes('**言語**:')) {
-        const langMatch = section.match(/\*\*言語\*\*: (.*?)$/m);
-        if (langMatch) languages = langMatch[1];
+        const langMatch = section.match(/\*\*言語\*\*: (.*)$/m);
+        if (langMatch) languages = langMatch[1].replace(/,/g, ', ');
       }
       
       if (section.includes('**OS')) {
-        const serverMatch = section.match(/\*\*OS[^:]*\*\*: (.*?)$/m);
-        if (serverMatch) servers = serverMatch[1];
+        const serverMatch = section.match(/\*\*OS[^:]*\*\*: (.*)$/m);
+        if (serverMatch) servers = serverMatch[1].replace(/,/g, ', ');
       }
       
       if (section.includes('**ツール**:')) {
-        const toolMatch = section.match(/\*\*ツール\*\*: (.*?)$/m);
-        if (toolMatch) tools = toolMatch[1];
+        const toolMatch = section.match(/\*\*ツール\*\*: (.*)$/m);
+        if (toolMatch) tools = toolMatch[1].replace(/,/g, ', ');
       }
       
       // 役割を抽出
       if (section.includes('**役割**:')) {
-        const roleMatch = section.match(/\*\*役割\*\*: (.*?)$/m);
+        const roleMatch = section.match(/\*\*役割\*\*: (.*)$/m);
         if (roleMatch) role = roleMatch[1];
       }
       
       // チーム規模を抽出
       if (section.includes('**チーム規模**:')) {
-        const teamMatch = section.match(/\*\*チーム規模\*\*: (.*?)$/m);
+        const teamMatch = section.match(/\*\*チーム規模\*\*: (.*)$/m);
         if (teamMatch) {
-          role += `\\n規模: ${teamMatch[1]}`;
+          role += `<br>規模: ${teamMatch[1]}`;
         }
       }
       
       // 担当工程を抽出
       if (section.includes('**担当工程**:')) {
-        const phaseMatch = section.match(/\*\*担当工程\*\*: (.*?)$/m);
+        const phaseMatch = section.match(/\*\*担当工程\*\*: (.*)$/m);
         if (phaseMatch) {
           const phaseText = phaseMatch[1];
           phases[0] = phaseText.includes('要件定義');
           phases[1] = phaseText.includes('基本設計');
           phases[2] = phaseText.includes('詳細設計');
-          phases[3] = phaseText.includes('製造・構築');
+          phases[3] = phaseText.includes('製造・構築') || phaseText.includes('製造') || phaseText.includes('構築');
           phases[4] = phaseText.includes('テスト');
-          phases[5] = phaseText.includes('保守・運用');
+          phases[5] = phaseText.includes('保守・運用') || phaseText.includes('保守') || phaseText.includes('運用');
         }
       }
       
@@ -481,7 +481,7 @@ function extractCareers(content) {
       });
       
       if (contentLines.length > 0) {
-        description = `■${description}\\n${contentLines.join('\\n')}`;
+        description = `■${description}<br>${contentLines.join('<br>')}`;
       }
       
       careers.push({

--- a/scripts/generate-index.js
+++ b/scripts/generate-index.js
@@ -6,10 +6,10 @@ const glob = require('glob');
 async function generateIndex() {
   console.log('Generating index.html for GitHub Pages...');
   
-  // 出力ディレクトリ内のファイルを検索
-  const pdfFiles = glob.sync('output/pdf/*.pdf').map(f => path.basename(f));
-  const excelFiles = glob.sync('output/excel/*.xlsx').map(f => path.basename(f));
-  const htmlFiles = glob.sync('output/html/*.html').map(f => path.basename(f));
+  // 出力ディレクトリ内のファイルを検索し、最新のみを取得
+  const pdfFiles = getLatestFiles(glob.sync('output/pdf/*.pdf'));
+  const excelFiles = getLatestFiles(glob.sync('output/excel/*.xlsx'));
+  const htmlFiles = getLatestFiles(glob.sync('output/html/*.html'));
   
   console.log('Found files:');
   console.log('PDFs:', pdfFiles);
@@ -50,7 +50,8 @@ async function generateIndex() {
         
         <div class="info">
             <strong>💡 自動生成されたスキルシートファイル</strong><br>
-            <a href="https://github.com/zukizukizuki/skill/blob/main/skill-sheets/zukizukizuki.md" target="_blank">Markdownファイル</a>から自動的に変換されたスキルシートをダウンロードできます。
+            <a href="https://github.com/zukizukizuki/skill/blob/main/skill-sheets/zukizukizuki.md" target="_blank">Markdownファイル</a>から自動的に変換されたスキルシートをダウンロードできます。<br>
+            <small>※ 個人情報は含まれていません。詳細な情報は個別にご提供いたします。</small>
         </div>
         
         ${pdfFiles.length === 0 ? `
@@ -109,6 +110,26 @@ async function generateIndex() {
   // index.htmlを出力ディレクトリに保存
   await fs.writeFile('output/index.html', indexHtml);
   console.log('✓ Generated index.html');
+}
+
+// 最新のファイルのみを取得する関数
+function getLatestFiles(files) {
+  if (files.length === 0) return [];
+  
+  // ファイル名から日付を抽出して最新のものを取得
+  const filesByBaseName = {};
+  
+  files.forEach(file => {
+    const basename = path.basename(file);
+    const nameWithoutExt = basename.replace(/\.(pdf|xlsx|html)$/, '');
+    const nameWithoutDate = nameWithoutExt.replace(/_\d{4}-\d{2}-\d{2}$/, '');
+    
+    if (!filesByBaseName[nameWithoutDate] || basename > filesByBaseName[nameWithoutDate]) {
+      filesByBaseName[nameWithoutDate] = basename;
+    }
+  });
+  
+  return Object.values(filesByBaseName);
 }
 
 // 実行


### PR DESCRIPTION
- Fix HTML conversion script to properly display career history
- Show only latest version files on GitHub Pages
- Add privacy notice about personal information

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 「職歴・プロジェクト経歴」セクションに、2012年4月から2025年までの詳細なキャリア・プロジェクト履歴表を追加しました。
- **ドキュメント**
  - スキルシート自動生成ファイルに個人情報が含まれない旨の注意書きを追加しました。
  - ダウンロードリンク一覧を最新ファイルのみに整理しました。  
- **スタイル**
  - 表示される箇条書きや改行のフォーマットをHTMLに合わせて改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->